### PR TITLE
fixed dropdown and hover state showing before link is hovered

### DIFF
--- a/components/nav/nav-platform-list/nav-platform-list.styl
+++ b/components/nav/nav-platform-list/nav-platform-list.styl
@@ -76,13 +76,14 @@ nav.platform-list
 			@extend .anim-back-in-up
 			@extend .anim-fade-leave
 			float: left
+			margin-right: ($grid-gutter-width / 2)
 
 		a
 			display: inline-block
 			border-left: 0
 			border-bottom-width: 3px
 			padding: 0 5px ($line-height-computed / 2) 0
-			margin: 0 ($grid-gutter-width / 2) 0 0
+			margin: 0
 
 			@media $media-xs
 				margin-right: ($grid-gutter-width-xs / 2)
@@ -169,8 +170,3 @@ nav.platform-list
 
 			&.active
 				color: $gray-lightest !important
-
-section.nav-only
-	nav.platform-list.inline
-		margin-top: $font-size-base
-		margin-bottom: 0


### PR DESCRIPTION
Presently the highlight state on  the platform nav shows when the li is hovered over, and the margin being present on the a inside the li allows the hover to be shown before the link is clickable. The related dropdown also shows at that time. This will correct that behavior. 
