### PR TITLE
Make comment titles grey instead of white

### DIFF
--- a/components/comment/widget/comment.styl
+++ b/components/comment/widget/comment.styl
@@ -34,7 +34,7 @@ $comment-gutter-size-xs = 40px
 		font-weight: bold
 
 		a
-			color: $text-color
+			color: $gray-dark
 
 			&:hover
 				text-decoration: underline


### PR DESCRIPTION
Live:
![image](https://user-images.githubusercontent.com/6004491/27261166-06adef76-5435-11e7-8edc-62219259e195.png)

Amended:
![image](https://user-images.githubusercontent.com/6004491/27261165-fd9c8500-5434-11e7-93dc-09259d1e4e27.png)


Closes gamejolt/issue-tracker#860