### PR TITLE
Fix jolticon positioning inside buttons

### DIFF
--- a/components/button/button.styl
+++ b/components/button/button.styl
@@ -98,9 +98,9 @@ button-variant( background, color, icon-color, addon-color, outline-color, outli
 
 	.jolticon
 		position: relative
-		top: 1px
+		top: -1px
 		cursor: pointer
-		vertical-align: text-top
+		vertical-align: middle
 		margin: 0 $button-icon-spacing-right 0 0
 
 	.jolticon-addon

--- a/components/button/button.styl
+++ b/components/button/button.styl
@@ -98,7 +98,7 @@ button-variant( background, color, icon-color, addon-color, outline-color, outli
 
 	.jolticon
 		position: relative
-		top: -1px
+		top: 1px
 		cursor: pointer
 		vertical-align: text-top
 		margin: 0 $button-icon-spacing-right 0 0


### PR DESCRIPTION
Currently they are slightly raised everywhere:

![image](https://user-images.githubusercontent.com/6004491/29192317-ea945fa6-7e18-11e7-85ef-60830a273caa.png)

After change:

![image](https://user-images.githubusercontent.com/6004491/29192325-f516ba28-7e18-11e7-8aba-8bfb33d19871.png)
