### PR TITLE
Turn off font smoothing for jolticons

### DIFF
--- a/components/jolticons/jolticons.styl
+++ b/components/jolticons/jolticons.styl
@@ -17,8 +17,8 @@ $jolticon-size = 16px
 	font-variant: normal
 	text-transform: none
 	line-height: 1
-
-	// -webkit-font-smoothing: none
+	
+	-webkit-font-smoothing: none
 	// -moz-osx-font-smoothing: none
 	// text-rendering: geometricPrecision
 


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/6004491/29193179-25ec3774-7e1c-11e7-984a-12b857172a04.png)

After:

![image](https://user-images.githubusercontent.com/6004491/29193195-2b388b6a-7e1c-11e7-97cc-88e0d32dac05.png)
