### PR TITLE
Standarize app-form-buttons and app-buttons

### DIFF
--- a/components/auth/join/join-form.vue
+++ b/components/auth/join/join-form.vue
@@ -88,7 +88,7 @@
 				block
 				solid
 				:disabled="Connection.isClientOffline || blocked"
-				@click.prevent="linkedChoose('facebook')"
+				@click="linkedChoose('facebook')"
 			>
 				<translate>Continue with Facebook</translate>
 			</app-button>
@@ -98,7 +98,7 @@
 				block
 				solid
 				:disabled="Connection.isClientOffline || blocked"
-				@click.prevent="linkedChoose('twitter')"
+				@click="linkedChoose('twitter')"
 			>
 				<translate>Continue with Twitter</translate>
 			</app-button>
@@ -108,7 +108,7 @@
 				block
 				solid
 				:disabled="Connection.isClientOffline || blocked"
-				@click.prevent="linkedChoose('google')"
+				@click="linkedChoose('google')"
 			>
 				<translate>Continue with Google</translate>
 			</app-button>
@@ -118,7 +118,7 @@
 				block
 				solid
 				:disabled="Connection.isClientOffline || blocked"
-				@click.prevent="linkedChoose('twitch')"
+				@click="linkedChoose('twitch')"
 			>
 				<translate>Continue with Twitch</translate>
 			</app-button>

--- a/components/auth/login/login-form.vue
+++ b/components/auth/login/login-form.vue
@@ -94,7 +94,7 @@
 				block
 				solid
 				:disabled="Connection.isClientOffline"
-				@click.prevent="linkedChoose('facebook')"
+				@click="linkedChoose('facebook')"
 			>
 				<translate>Continue with Facebook</translate>
 			</app-button>
@@ -104,7 +104,7 @@
 				block
 				solid
 				:disabled="Connection.isClientOffline"
-				@click.prevent="linkedChoose('twitter')"
+				@click="linkedChoose('twitter')"
 			>
 				<translate>Continue with Twitter</translate>
 			</app-button>
@@ -114,7 +114,7 @@
 				block
 				solid
 				:disabled="Connection.isClientOffline"
-				@click.prevent="linkedChoose('google')"
+				@click="linkedChoose('google')"
 			>
 				<translate>Continue with Google</translate>
 			</app-button>
@@ -124,7 +124,7 @@
 				block
 				solid
 				:disabled="Connection.isClientOffline"
-				@click.prevent="linkedChoose('twitch')"
+				@click="linkedChoose('twitch')"
 			>
 				<translate>Continue with Twitch</translate>
 			</app-button>

--- a/components/button/button.vue
+++ b/components/button/button.vue
@@ -1,6 +1,7 @@
 <template>
 	<component
 		:is="ourTag"
+		type="button"
 		class="button"
 		:class="{
 			'-primary': this.primary,

--- a/components/colorpicker/colorpicker.vue
+++ b/components/colorpicker/colorpicker.vue
@@ -17,12 +17,12 @@
 
 				<div class="colorpicker-well">
 					<div class="col">
-						<app-button primary solid block @click.prevent="accept">
+						<app-button primary solid block @click="accept">
 							<translate>Accept</translate>
 						</app-button>
 					</div>
 					<div class="col">
-						<app-button trans block @click.prevent="cancel">
+						<app-button trans block @click="cancel">
 							<translate>Cancel</translate>
 						</app-button>
 					</div>

--- a/components/comment/add/add.vue
+++ b/components/comment/add/add.vue
@@ -26,7 +26,7 @@
 				<translate v-else-if="method === 'edit'">Save</translate>
 			</app-form-button>
 
-			<app-button v-if="method === 'edit'" trans @click.prevent="onCancel">
+			<app-button v-if="method === 'edit'" trans @click="onCancel">
 				<translate>Cancel</translate>
 			</app-button>
 		</div>

--- a/components/content/components/base/base-content-component.vue
+++ b/components/content/components/base/base-content-component.vue
@@ -7,14 +7,14 @@
 				overlay
 				icon="edit"
 				:disabled="isDisabled"
-				@click.prevent="onEditClicked"
+				@click="onEditClicked"
 			/>
 			<app-button
 				circle
 				overlay
 				icon="remove"
 				:disabled="isDisabled"
-				@click.prevent="onRemovedClicked"
+				@click="onRemovedClicked"
 			/>
 		</div>
 

--- a/components/content/content-editor/controls/block/controls.vue
+++ b/components/content/content-editor/controls/block/controls.vue
@@ -17,64 +17,72 @@
 				<template v-if="Screen.isXs">
 					<button
 						v-if="capabilities.media"
+						type="button"
 						class="control-button"
-						@click.prevent="onClickMedia"
+						@click="onClickMedia"
 						v-app-tooltip="$gettext('Add an image or GIF')"
 					>
 						<app-jolticon icon="screenshot" />
 					</button>
 					<button
 						v-if="capabilities.hasAnyEmbed"
+						type="button"
 						class="control-button"
-						@click.prevent="onClickEmbed"
+						@click="onClickEmbed"
 						v-app-tooltip="$gettext('Add an embed')"
 					>
 						<app-jolticon icon="embed" />
 					</button>
 					<button
 						v-if="capabilities.codeBlock"
+						type="button"
 						class="control-button"
-						@click.prevent="onClickCodeBlock"
+						@click="onClickCodeBlock"
 						v-app-tooltip="$gettext('Add a code block')"
 					>
 						<app-jolticon icon="brackets" />
 					</button>
 					<button
 						v-if="capabilities.blockquote"
+						type="button"
 						class="control-button"
-						@click.prevent="onClickBlockquote"
+						@click="onClickBlockquote"
 						v-app-tooltip="$gettext('Add a quote')"
 					>
 						<app-jolticon icon="blockquote" />
 					</button>
 					<button
 						v-if="capabilities.spoiler"
+						type="button"
 						class="control-button"
-						@click.prevent="onClickSpoiler"
+						@click="onClickSpoiler"
 						v-app-tooltip="$gettext('Add a spoiler')"
 					>
 						<app-jolticon icon="inactive" />
 					</button>
 					<button
 						v-if="capabilities.hr"
+						type="button"
 						class="control-button"
-						@click.prevent="onClickHr"
+						@click="onClickHr"
 						v-app-tooltip="$gettext('Add a separator')"
 					>
 						<app-jolticon icon="hr" />
 					</button>
 					<button
 						v-if="capabilities.list"
+						type="button"
 						class="control-button"
-						@click.prevent="onClickBulletList"
+						@click="onClickBulletList"
 						v-app-tooltip="$gettext('Add a bulleted list')"
 					>
 						<app-jolticon icon="bullet-list" />
 					</button>
 					<button
 						v-if="capabilities.list"
+						type="button"
 						class="control-button"
-						@click.prevent="onClickOrderedList"
+						@click="onClickOrderedList"
 						v-app-tooltip="$gettext('Add a numbered list')"
 					>
 						<app-jolticon icon="numbered-list" />
@@ -89,7 +97,7 @@
 						circle
 						solid
 						:icon="'add'"
-						@click.prevent="onClickExpand"
+						@click="onClickExpand"
 					/>
 					<transition name="fade">
 						<span v-if="!this.collapsed">
@@ -100,7 +108,7 @@
 								circle
 								solid
 								icon="screenshot"
-								@click.prevent="onClickMedia"
+								@click="onClickMedia"
 								v-app-tooltip="$gettext('Add an image or GIF')"
 							/>
 							<app-button
@@ -109,7 +117,7 @@
 								circle
 								solid
 								icon="embed"
-								@click.prevent="onClickEmbed"
+								@click="onClickEmbed"
 								v-app-tooltip="$gettext('Add an embed')"
 							/>
 							<app-button
@@ -118,7 +126,7 @@
 								circle
 								solid
 								icon="brackets"
-								@click.prevent="onClickCodeBlock"
+								@click="onClickCodeBlock"
 								v-app-tooltip="$gettext('Add a code block')"
 							/>
 							<app-button
@@ -127,7 +135,7 @@
 								circle
 								solid
 								icon="blockquote"
-								@click.prevent="onClickBlockquote"
+								@click="onClickBlockquote"
 								v-app-tooltip="$gettext('Add a quote')"
 							/>
 							<app-button
@@ -136,7 +144,7 @@
 								circle
 								solid
 								icon="inactive"
-								@click.prevent="onClickSpoiler"
+								@click="onClickSpoiler"
 								v-app-tooltip="$gettext('Add a spoiler')"
 							/>
 							<app-button
@@ -145,7 +153,7 @@
 								circle
 								solid
 								icon="hr"
-								@click.prevent="onClickHr"
+								@click="onClickHr"
 								v-app-tooltip="$gettext('Add a separator')"
 							/>
 							<app-button
@@ -154,7 +162,7 @@
 								circle
 								solid
 								icon="bullet-list"
-								@click.prevent="onClickBulletList"
+								@click="onClickBulletList"
 								v-app-tooltip="$gettext('Add a bulleted list')"
 							/>
 							<app-button
@@ -163,7 +171,7 @@
 								circle
 								solid
 								icon="numbered-list"
-								@click.prevent="onClickOrderedList"
+								@click="onClickOrderedList"
 								v-app-tooltip="$gettext('Add a numbered list')"
 							/>
 						</span>

--- a/components/content/content-editor/modals/gif/gif-modal.vue
+++ b/components/content/content-editor/modals/gif/gif-modal.vue
@@ -9,7 +9,7 @@
 		<div class="modal-body">
 			<div v-if="hasError" class="error-container">
 				<p><translate>Something went wrong.</translate></p>
-				<app-button @click.prevent="onRetry"><translate>Retry</translate></app-button>
+				<app-button @click="onRetry"><translate>Retry</translate></app-button>
 			</div>
 
 			<template v-else>
@@ -19,11 +19,11 @@
 						trans
 						icon="chevron-left"
 						v-if="shouldShowResetButton"
-						@click.prevent="onClickReset"
+						@click="onClickReset"
 					/>
 					<div class="search-bar">
 						<app-jolticon icon="search" class="search-icon text-muted" />
-						<div v-if="shouldShowResetButton" class="search-clear" @click.prevent="onClickReset">
+						<div v-if="shouldShowResetButton" class="search-clear" @click="onClickReset">
 							<app-jolticon class="-icon" icon="remove" />
 						</div>
 						<input
@@ -56,7 +56,7 @@
 							:style="{
 								'animation-delay': category.index * 0.02 + 's',
 							}"
-							@click.prevent="onClickCategory(category.searchterm)"
+							@click="onClickCategory(category.searchterm)"
 						>
 							<div class="category">
 								<img :src="category.previewGif" />
@@ -103,7 +103,7 @@
 							</span>
 						</div>
 						<div v-else-if="shouldShowMoreButton" class="more-container">
-							<app-button @click.prevent="loadNextPage">More</app-button>
+							<app-button @click="loadNextPage">More</app-button>
 						</div>
 					</div>
 				</div>

--- a/components/form-vue/button/button.ts
+++ b/components/form-vue/button/button.ts
@@ -11,6 +11,7 @@ export default class AppFormButton extends Vue {
 	@Prop({ type: Boolean, default: true }) solid!: boolean;
 	@Prop(Boolean) block!: boolean;
 	@Prop(Boolean) lg!: boolean;
+	@Prop(String) icon?: string;
 
 	form!: AppFormTS;
 

--- a/components/form-vue/button/button.ts
+++ b/components/form-vue/button/button.ts
@@ -25,4 +25,28 @@ export default class AppFormButton extends Vue {
 	created() {
 		this.form = findRequiredVueParent(this, require('../form.vue').default) as AppFormTS;
 	}
+
+	// The app-button component used to automatically submit forms through
+	// the native default behaviour of it's underlying <button> element.
+	// (the <button> element's type attribute is considered to be 'submit' when unspecified),
+	// so in places where we wanted to use app-button in forms without submitting the form
+	// we'd add a @click.prevent on it.
+	//
+	// The problem with this is that if app-buttons are v-if'ed away in a transition,
+	// they Vue vm for the elements is destroyed and all non native vue event handlers we set
+	// on the element are unbound (including the @click.prevent) before the transition ends.
+	// This means that during the time between the component being v-ifed away and the transition ending
+	// clicks that happen on the component will not get prevented - resulting in the form being submitted.
+	//
+	// To fix this, we set the default behaviour of app-button to not submit the form, and set a NATIVE
+	// click event handler on the app-form-button component to manually submit the form.
+	async onClick(e: Event) {
+		this.$emit('before-submit', e);
+		if (e.defaultPrevented) {
+			return;
+		}
+
+		const result = await this.form.submit();
+		this.$emit('after-submit', e, result);
+	}
 }

--- a/components/form-vue/button/button.vue
+++ b/components/form-vue/button/button.vue
@@ -6,6 +6,7 @@
 		:solid="solid"
 		:block="block"
 		:disabled="form.base.state.isProcessing"
+		:icon="icon"
 		@click.native="onClick"
 	>
 		<slot />

--- a/components/form-vue/button/button.vue
+++ b/components/form-vue/button/button.vue
@@ -6,6 +6,7 @@
 		:solid="solid"
 		:block="block"
 		:disabled="form.base.state.isProcessing"
+		@click.native="onClick"
 	>
 		<slot />
 		<transition>

--- a/components/form-vue/control/markdown/media-items/media-items.vue
+++ b/components/form-vue/control/markdown/media-items/media-items.vue
@@ -18,7 +18,7 @@
 									overlay
 									sparse
 									v-app-tooltip="$gettext(`Copy Markdown Embed`)"
-									@click.prevent="copyLink(item)"
+									@click="copyLink(item)"
 								/>
 							</div>
 

--- a/components/form-vue/control/theme/theme.vue
+++ b/components/form-vue/control/theme/theme.vue
@@ -50,7 +50,7 @@
 						<br />
 					</div>
 
-					<app-button v-if="!!controlVal" block trans @click.stop.prevent="clear()">
+					<app-button v-if="!!controlVal" block trans @click="clear()">
 						<translate>Clear Theme</translate>
 					</app-button>
 				</div>

--- a/components/form-vue/legend/legend.vue
+++ b/components/form-vue/legend/legend.vue
@@ -11,8 +11,7 @@
 			<div class="-label"><slot /></div>
 			<div class="-compactbar" v-if="compact" />
 			<div class="-delete" v-if="deletable">
-				<!-- Make sure it doesn't bubble up the click since it's in a form -->
-				<app-button sparse circle icon="remove" @click.prevent="emitDelete()" />
+				<app-button sparse circle icon="remove" @click="emitDelete()" />
 			</div>
 		</div>
 	</legend>

--- a/components/game/package/payment-form/payment-form.ts
+++ b/components/game/package/payment-form/payment-form.ts
@@ -251,12 +251,10 @@ export default class FormGamePackagePayment extends BaseForm<any>
 
 	checkoutCard() {
 		this.checkoutType = 'cc-stripe';
-		this.$refs.form.submit();
 	}
 
 	checkoutPaypal() {
 		this.checkoutType = 'paypal';
-		this.$refs.form.submit();
 	}
 
 	startOver() {

--- a/components/game/package/payment-form/payment-form.vue
+++ b/components/game/package/payment-form/payment-form.vue
@@ -100,16 +100,16 @@
 							</p>
 
 							<p>
-								<app-button primary sparse @click.prevent="addMoney(1)">
+								<app-button primary sparse @click="addMoney(1)">
 									+$1
 								</app-button>
-								<app-button primary sparse @click.prevent="addMoney(2)">
+								<app-button primary sparse @click="addMoney(2)">
 									+$2
 								</app-button>
-								<app-button primary sparse @click.prevent="addMoney(5)">
+								<app-button primary sparse @click="addMoney(5)">
 									+$5
 								</app-button>
-								<app-button primary sparse @click.prevent="addMoney(10)">
+								<app-button primary sparse @click="addMoney(10)">
 									+$10
 								</app-button>
 							</p>
@@ -243,16 +243,16 @@
 								</template>
 							</app-expand>
 
-							<app-button icon="credit-card" :disabled="!valid" @click.prevent="checkoutCard()">
+							<app-form-button icon="credit-card" :solid="false" :primary="false" :disabled="!valid" @before-submit="checkoutCard()">
 								<template v-if="cards.length">
 									<translate>New Card</translate>
 								</template>
 								<template v-else>
 									<translate>Card</translate>
 								</template>
-							</app-button>
+							</app-form-button>
 
-							<app-button :disabled="!valid" @click.prevent="collectAddress('paypal')">
+							<app-button :disabled="!valid" @click="collectAddress('paypal')">
 								<translate>PayPal</translate>
 							</app-button>
 						</div>
@@ -318,9 +318,9 @@
 						</div>
 
 						<div v-if="checkoutType === 'paypal'">
-							<app-button primary :disabled="!valid" @click.prevent="checkoutPaypal">
+							<app-form-button :solid="false" :disabled="!valid" @before-submit="checkoutPaypal()">
 								<translate>Proceed to PayPal</translate>
-							</app-button>
+							</app-form-button>
 						</div>
 						<div v-else-if="checkoutType === 'wallet'">
 							<app-loading
@@ -348,7 +348,7 @@
 							<app-button
 								primary
 								:disabled="!valid || !calculatedAddressTax || !hasSufficientWalletFunds"
-								@click.prevent="checkoutWallet"
+								@click="checkoutWallet"
 							>
 								<translate>Buy Using Wallet</translate>
 								<small v-if="calculatedAddressTax">


### PR DESCRIPTION
`app-buttons` by default have a type="button" attribute on them which means they no longer submit forms.
`app-form-buttons` now fire 'before-submit' and 'after-submit' events instead of 'click'.

standarized the usage of those components across the codebase.