### PR TITLE
unfocus button after click event

### DIFF
--- a/components/button/button.ts
+++ b/components/button/button.ts
@@ -25,6 +25,10 @@ export default class AppButton extends Vue {
 	@Prop(String) badge?: string;
 	@Prop() to?: any;
 
+	$refs!: {
+		button: HTMLElement;
+	};
+
 	get ourTag() {
 		if (this.$attrs.href) {
 			return 'a';
@@ -36,5 +40,6 @@ export default class AppButton extends Vue {
 
 	onClick(e: Event) {
 		this.$emit('click', e);
+		this.$refs.button.blur();
 	}
 }

--- a/components/button/button.vue
+++ b/components/button/button.vue
@@ -19,6 +19,7 @@
 		:to="to"
 		:disabled="this.disabled"
 		@click="onClick"
+		ref="button"
 	>
 		<span v-if="badge" class="-badge">{{ badge }}</span>
 		<app-jolticon class="-icon" v-if="icon" :icon="icon" :big="lg" />


### PR DESCRIPTION
On mobile buttons stay filled in when clicked because they retain their focus.
This makes Like buttons look like they are still in the "Liked" state after unliking.

Fixes https://github.com/gamejolt/issue-tracker/issues/1309