### PR TITLE
Update the fixedTime when the date changes

### DIFF
--- a/components/time/ago/ago.ts
+++ b/components/time/ago/ago.ts
@@ -23,7 +23,6 @@ export class AppTimeAgo extends Vue {
 	private fixedTime = '';
 
 	created() {
-		this.fixedTime = date(this.date, 'medium');
 		this.refresh();
 	}
 
@@ -67,6 +66,8 @@ export class AppTimeAgo extends Vue {
 		} else if (diff < 180) {
 			secondsUntilUpdate = 300;
 		}
+
+		this.fixedTime = date(this.date, 'medium');
 
 		if (!GJ_IS_SSR) {
 			this.timeout = window.setTimeout(() => this.refresh(), secondsUntilUpdate * 1000);


### PR DESCRIPTION
A small fix in the `AppTimeAgo` component where the `fixedTime` isn't updated when the date changes.

I noticed this issue when I viewed a Game Jolt profile and hovered over the join date. First time it's correct but when you navigate to another profile the date is not updated (It shows the joined date for the previous user). This should fix that issue.